### PR TITLE
ページ全体の設定を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,24 @@
  *= require_tree .
  *= require_self
  */
+
+/* 全体 */
+
+.base-container {
+  margin: 0 auto;
+  padding: 1rem;
+}
+
+/* max-width */
+
+.mw-md {
+  max-width: 720px;
+}
+
+.mw-lg {
+  max-width: 960px;
+}
+
+.mw-xl {
+  max-width: 1200px;
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def max_width
+    # 後に条件分岐が必要
+    "mw-xl"
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,11 +4,10 @@
     <title>GyakutenCloneGroup</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <%= stylesheet_link_tag 'application', media: 'all', 'data-turbolinks-track': 'reload' %>
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
-
   <body>
     <%= yield %>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,15 @@
     <%= javascript_pack_tag 'application', 'data-turbolinks-track': 'reload' %>
   </head>
   <body>
-    <%= yield %>
-  </body>
-</html>
+    <header>
+    </header>
+    <main>
+      <#% max_width メソッドは application_helper.rb に記載 %>
+        <div class="base-container <%= max_width %>">
+          <%= yield %>
+        </div>
+      </main>
+      <footer>
+      </footer>
+    </body>
+  </html>


### PR DESCRIPTION
 

# 実装内容

ページ全体の設定を追加

## issue 番号

close #3

## 概要

1. スマホ用ビューポートの設定を追加（applocation.html.erb)
2. ページ全体に適用するレイアウトを設定するための「クラス」、「メソッド」を設定（application.html.erb)
3. 全ページに共通のレイアウトをCSSファイルに設定（application.css)
4. 2で設定した、CSSで使用するメソッドを定義（application_helper.rb )

## 参考資料

(https://developers.google.com/web/fundamentals/design-and-ux/responsive?hl=ja#set-the-viewport)


## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考（必要があれば）
