### PR TITLE
Railsテキスト教材一覧ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,3 +30,9 @@ div.text-card-container {
   padding-right: 9px;
   margin-bottom: 50px;
 }
+
+div.content-card {
+  height: 370px;
+  max-width: 376px;
+  margin: 0 auto;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -25,3 +25,8 @@
 .mw-xl {
   max-width: 1200px;
 }
+div.text-card-container {
+  padding-left: 9px;
+  padding-right: 9px;
+  margin-bottom: 50px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -36,3 +36,7 @@ div.content-card {
   max-width: 376px;
   margin: 0 auto;
 }
+
+.text-title{
+  margin-top: 30px;
+}

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,4 +4,8 @@ class TextsController < ApplicationController
     @texts = Text.order(id: :asc)
   end
 
+  def show
+    @texts = Text.find()
+  end
+
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,9 +4,7 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).order(id: :asc)
   end
 
-  def show
-    @text = Text.find(params[:id])
-  end
+  
   
 
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,8 +4,6 @@ class TextsController < ApplicationController
     @texts = Text.order(id: :asc)
   end
 
-  def show
-    @texts = Text.find()
-  end
+  
 
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,7 +1,7 @@
 class TextsController < ApplicationController
 
-def index
-  @texts = Text.order(id: :asc)
-end
+  def index
+    @texts = Text.order(id: :asc)
+  end
 
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,6 +4,9 @@ class TextsController < ApplicationController
     @texts = Text.order(id: :asc)
   end
 
+  def show
+    @text = Text.find(params[:id])
+  end
   
 
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,7 +1,7 @@
 class TextsController < ApplicationController
 
   def index
-    @texts = Text.order(id: :asc)
+    @texts = Text.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).order(id: :asc)
   end
 
   def show

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -1,7 +1,7 @@
 class TextsController < ApplicationController
 
 def index
- 
+  @texts = Text.order(id: :asc)
 end
 
 end

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,20 +1,11 @@
 <button type="button" class="btn btn-primary">Primary</button>
-<h1>投稿一覧</h1>
-<table>
-  <thead>
-    <tr>
-      <th scope="col">No.</th>
-      <th scope="col">タイトル</th>
-      <th scope="col"></th>
-    </tr>
-  </thead>
-  <tbody>
-    <% @texts.each.with_index(1) do |texts, i| %>
-      <tr>
-        <th scope="row"><%= i %></th>
-        <td><%= texts.title %></td>
-        <td><%= texts.genre %></td>
-      </tr>
-    <% end %>
-  </tbody>
-</table>
+<h1>テキスト教材</h1>
+  <% @texts.each.with_index(1) do |texts, i| %>    
+    <div class="card" style="width: 18rem;">
+      <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+      <div class="card-body">
+        <p class="card-text"><%= texts.title %></p>
+        <p class="card-text"><%= texts.genre %></p>
+      </div>
+    </div>
+  <% end %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,19 +1,21 @@
 <button type="button" class="btn btn-primary">Primary</button>
 <h1>テキスト教材</h1>
 <div class="container">
-<div class="row">
-  <div class="col-12 col-md-6 col-lg-4 text-card-container">
-      <% @texts.each.with_index(1) do |texts, i| %>
-        <div class="card content-card border-dark mb-3">
-          <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-          <div class="card-body">
-            <p class="card-text">
-              <%= texts.title %>
-            </p>
-            <p><%= texts.genre %></p>
+  <div class="row">
+    
+        <% @texts.each.with_index(1) do |texts, i| %>
+          <div class="col-12 col-md-6 col-lg-4 text-card-container">
+            <div class="card content-card border-dark mb-3">
+              <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+              <div class="card-body">
+                <p class="card-text">
+                  <%= texts.title %>
+                </p>
+                <p><%= texts.genre %></p>
+              </div>
+            </div>
           </div>
-        </div>
-      <% end %>
-    </div>
-</div>
+        <% end %>
+      
+  </div>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -2,24 +2,24 @@
 
   <div class="row">
     <% @texts.each.with_index(1) do |text , i| %>
-        <div class="col-12 col-md-6 col-lg-4 text-card-container">
-            <div class="card content-card border-dark mb-3">
-              <%= link_to text, target: :_blank do %>
-                  <div class="card-header p-0">
-                    <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="img-fluid" >
-                  </div>
-                  <div class="card-body">
-                    <div id="button-plan">
-                      <p>ボタン予定地（ボタン実装時にここを編集してください）</p>
-                    </div>
-                    <p class="card-text txet-title">
-                      <%= text.title %>
-                    </p>
-                    <p><%= text.genre %></p>
-                  </div>
-              <% end %>
+      <div class="col-12 col-md-6 col-lg-4 text-card-container">
+        <div class="card content-card border-dark mb-3">
+          <%= link_to text, target: :_blank do %>
+            <div class="card-header p-0">
+              <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="img-fluid" >
             </div>
+            <div class="card-body">
+              <div id="button-plan">
+                <p>ボタン予定地（ボタン実装時にここを編集してください）</p>
+              </div>
+              <p class="card-text txet-title">
+                <%= text.title %>
+              </p>
+              <p><%= text.genre %></p>
+            </div>
+          <% end %>
         </div>
+      </div>
     <% end %>
   </div>
 </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,26 +1,23 @@
-<button type="button" class="btn btn-primary">Primary</button>
 <h1>テキスト教材</h1>
 <div class="container">
   <div class="row">
-    
-        <% @texts.each.with_index(1) do |text , i| %>
-          <div class="col-12 col-md-6 col-lg-4 text-card-container">
+    <% @texts.each.with_index(1) do |text , i| %>
+        <div class="col-12 col-md-6 col-lg-4 text-card-container">
+          <%= link_to "https://getbootstrap.jp/docs/4.5/layout/grid/", target: :_blank do %>
             <div class="card content-card border-dark mb-3">
-              <%# <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg> %>
               <div class="card-header p-0">
-                <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%">
+                <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%" height="auto">
               </div>
-              
-                <div class="card-body">
+              <div class="card-body">
                 <p class="card-text txet-title">
                   <%= text.title %>
                 </p>
                 <p><%= text.genre %></p>
               </div>
             </div>
-          </div>
-        <% end %>
-      
+          <% end %>
+        </div>
+    <% end %>
   </div>
 </div>
 <%= link_to "投稿一覧", texts_path, target: :_blank %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,1 +1,20 @@
 <button type="button" class="btn btn-primary">Primary</button>
+<h1>投稿一覧</h1>
+<table>
+  <thead>
+    <tr>
+      <th scope="col">No.</th>
+      <th scope="col">タイトル</th>
+      <th scope="col"></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @texts.each.with_index(1) do |texts, i| %>
+      <tr>
+        <th scope="row"><%= i %></th>
+        <td><%= texts.title %></td>
+        <td><%= texts.genre %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,21 +1,22 @@
 <h1>テキスト教材</h1>
-<div class="container">
+
   <div class="row">
     <% @texts.each.with_index(1) do |text , i| %>
         <div class="col-12 col-md-6 col-lg-4 text-card-container">
-          <%= link_to text, target: :_blank do %>
             <div class="card content-card border-dark mb-3">
-              <div class="card-header p-0">
-                <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%" height="auto">
-              </div>
-              <div class="card-body">
-                <p class="card-text txet-title">
-                  <%= text.title %>
-                </p>
-                <p><%= text.genre %></p>
-              </div>
+              <%= link_to text, target: :_blank do %>
+                <div class="card-header p-0">
+                  <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg"  >
+                </div>
+                <div class="card-body">
+                  <p class="card-text txet-title">
+                    <%= text.title %>
+                  </p>
+                  <p><%= text.genre %></p>
+                </div>
+              <% end %>
             </div>
-          <% end %>
+          
         </div>
     <% end %>
   </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -8,7 +8,7 @@
             <div class="card content-card border-dark mb-3">
               <%# <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg> %>
               <div class="card-header p-0">
-                <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
+                <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%">
               </div>
               
                 <div class="card-body">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -3,7 +3,7 @@
   <div class="row">
     <% @texts.each.with_index(1) do |text , i| %>
         <div class="col-12 col-md-6 col-lg-4 text-card-container">
-          <%= link_to "https://getbootstrap.jp/docs/4.5/layout/grid/", target: :_blank do %>
+          <%= link_to text, target: :_blank do %>
             <div class="card content-card border-dark mb-3">
               <div class="card-header p-0">
                 <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" width="100%" height="auto">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -23,4 +23,3 @@
     <% end %>
   </div>
 </div>
-<%= link_to "投稿一覧", texts_path, target: :_blank %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -4,7 +4,7 @@
     <% @texts.each.with_index(1) do |text , i| %>
       <div class="col-12 col-md-6 col-lg-4 text-card-container">
         <div class="card content-card border-dark mb-3">
-          <%= link_to text, target: :_blank do %>
+          <%= link_to text, target: :_blank, class: "text-decoration-none text-dark" do %>
             <div class="card-header p-0">
               <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="img-fluid" >
             </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -1,11 +1,19 @@
 <button type="button" class="btn btn-primary">Primary</button>
 <h1>テキスト教材</h1>
-  <% @texts.each.with_index(1) do |texts, i| %>    
-    <div class="card" style="width: 18rem;">
-      <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-      <div class="card-body">
-        <p class="card-text"><%= texts.title %></p>
-        <p class="card-text"><%= texts.genre %></p>
-      </div>
+<div class="container">
+<div class="row">
+  <div class="col-12 col-md-6 col-lg-4 text-card-container">
+      <% @texts.each.with_index(1) do |texts, i| %>
+        <div class="card content-card border-dark mb-3">
+          <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
+          <div class="card-body">
+            <p class="card-text">
+              <%= texts.title %>
+            </p>
+            <p><%= texts.genre %></p>
+          </div>
+        </div>
+      <% end %>
     </div>
-  <% end %>
+</div>
+</div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -3,15 +3,19 @@
 <div class="container">
   <div class="row">
     
-        <% @texts.each.with_index(1) do |texts, i| %>
+        <% @texts.each.with_index(1) do |text , i| %>
           <div class="col-12 col-md-6 col-lg-4 text-card-container">
             <div class="card content-card border-dark mb-3">
-              <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg>
-              <div class="card-body">
-                <p class="card-text">
-                  <%= texts.title %>
+              <%# <svg class="bd-placeholder-img card-img-top" width="100%" height="180" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="xMidYMid slice" focusable="false" role="img" aria-label="Placeholder: Image cap"><title>Placeholder</title><rect width="100%" height="100%" fill="#868e96"/><text x="50%" y="50%" fill="#dee2e6" dy=".3em">Image cap</text></svg> %>
+              <div class="card-header p-0">
+                <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg">
+              </div>
+              
+                <div class="card-body">
+                <p class="card-text txet-title">
+                  <%= text.title %>
                 </p>
-                <p><%= texts.genre %></p>
+                <p><%= text.genre %></p>
               </div>
             </div>
           </div>
@@ -19,3 +23,4 @@
       
   </div>
 </div>
+<%= link_to "投稿一覧", texts_path, target: :_blank %>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -6,7 +6,7 @@
             <div class="card content-card border-dark mb-3">
               <%= link_to text, target: :_blank do %>
                 <div class="card-header p-0">
-                  <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg"  >
+                  <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="img-fluid" >
                 </div>
                 <div class="card-body">
                   <p class="card-text txet-title">

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -12,10 +12,10 @@
                     <div id="button-plan">
                       <p>ボタン予定地（ボタン実装時にここを編集してください）</p>
                     </div>
-                      <p class="card-text txet-title">
-                        <%= text.title %>
-                      </p>
-                      <p><%= text.genre %></p>
+                    <p class="card-text txet-title">
+                      <%= text.title %>
+                    </p>
+                    <p><%= text.genre %></p>
                   </div>
               <% end %>
             </div>

--- a/app/views/texts/index.html.erb
+++ b/app/views/texts/index.html.erb
@@ -5,18 +5,20 @@
         <div class="col-12 col-md-6 col-lg-4 text-card-container">
             <div class="card content-card border-dark mb-3">
               <%= link_to text, target: :_blank do %>
-                <div class="card-header p-0">
-                  <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="img-fluid" >
-                </div>
-                <div class="card-body">
-                  <p class="card-text txet-title">
-                    <%= text.title %>
-                  </p>
-                  <p><%= text.genre %></p>
-                </div>
+                  <div class="card-header p-0">
+                    <img src="https://d5izmuz0mcjzz.cloudfront.net/texts/no_image.jpg" class="img-fluid" >
+                  </div>
+                  <div class="card-body">
+                    <div id="button-plan">
+                      <p>ボタン予定地（ボタン実装時にここを編集してください）</p>
+                    </div>
+                      <p class="card-text txet-title">
+                        <%= text.title %>
+                      </p>
+                      <p><%= text.genre %></p>
+                  </div>
               <% end %>
             </div>
-          
         </div>
     <% end %>
   </div>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,1 @@
+<%= @text.content %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,1 +1,0 @@
-<%= @text.content %>


### PR DESCRIPTION
## close #15

## 実装内容

- Railsテキスト教材一覧表示機能の実装
　- `Cards`スタイルにて実装
　-  `Grid System` を導入
　- クローンサイトに表示を寄せた
　- カード全体にリンク機能を適用

## 参考文献

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## 備考
- ナビバーが完成していないため、教材一覧リンク導入は別タスクとする
- show.html.erbは別タスクとするため削除