### PR TITLE
Rails動画教材ページの実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -49,3 +49,15 @@ div.content-card {
 .alert-alert {
   @extend .alert-danger;
 }
+
+/* 動画一覧ページ */
+
+.movie-body {
+  height: 190px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.movie-title {
+  margin-top: 1rem;
+}

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,0 +1,4 @@
+class MoviesController < ApplicationController
+  def index
+  end
+end

--- a/app/controllers/movies_controller.rb
+++ b/app/controllers/movies_controller.rb
@@ -1,4 +1,5 @@
 class MoviesController < ApplicationController
   def index
+    @movies = Movie.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).order(id: :asc)
   end
 end

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,0 +1,2 @@
+<h1>Movies#index</h1>
+<p>Find me in app/views/movies/index.html.erb</p>

--- a/app/views/movies/index.html.erb
+++ b/app/views/movies/index.html.erb
@@ -1,2 +1,26 @@
-<h1>Movies#index</h1>
-<p>Find me in app/views/movies/index.html.erb</p>
+<div class="base-container mw-xl">
+  <div class="container-fluid">
+    <div class="row">
+      <% @movies.each.with_index(1) do |movie, i| %>
+        <div class="col-12 col-md-6 col-lg-4">
+          <%# <div class="card-border-dark mb-3"> %>
+          <div class="card border-dark mb-3">
+            <div class="card-header p-0">
+              <div class="embed-responsive embed-responsive-16by9">
+                <iframe class="embed-responsive-item" src="<%= movie.url %>"></iframe>
+              </div>
+            </div>
+            <div class="card-body text-dark movie-body">
+              <!-- ここに「視聴済み機能」を実装(以下を編集) -->
+              <button class="btn btn-secondary btn-block">視聴済みにする</button>
+              <p class="card-text movie-title">
+                Lv.<%= i %> ：
+                <%= movie.title %>
+              </p>
+            </div>
+          </div>
+        </div>
+      <% end %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@ Rails.application.routes.draw do
   devise_for :admin_users, ActiveAdmin::Devise.config
   ActiveAdmin.routes(self)
   devise_for :users
-  root to: 'texts#index'
+  root to: "texts#index"
 
   resources :texts, only: [:index, :show]
+  resources :movies, only: [:index, :show]
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION

## issue 番号

- close #17

## 実装内容

- 動画教材ページへのルーティングを作成 
- ｢indexコントローラ」と「indexビューファイル」を作成 
  - indexアクションの処理を作成 
    - 表示するジャンルを限定する設定を記述 
  - ビューファイルに表示内容を記述 
    - scssファイルにスタイルを適用

## 参考資料

- [【公式】Bootstrap Cards](https://getbootstrap.jp/docs/4.5/components/card/)
- [【公式】Bootstrap Grid system](https://getbootstrap.jp/docs/4.5/layout/grid/)
- [【やんばるコード教材 Bootstrap】](https://arcane-gorge-21903.herokuapp.com/texts/261

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確

## 備考 

- ナビバーの動画教材ページへのリンク機能は別タスクとする 
- 視聴済み機能(表示さてているボタンはダミーです)、ページネーションは別タスクとする
