### PR TITLE
Railsテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,10 @@ gem "webpacker", "~> 4.0"
 gem "turbolinks", "~> 5"
 gem "jbuilder", "~> 2.7"
 gem "bootsnap", ">= 1.4.2", require: false
+# markdown
+gem 'redcarpet'
+# シンタックスハイライト
+gem 'coderay'
 # ログイン機能
 gem "devise"
 gem "activeadmin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -193,6 +193,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.1)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -250,6 +251,7 @@ DEPENDENCIES
   activeadmin
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views (~> 1.0)
   devise-i18n
@@ -260,6 +262,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -4,5 +4,9 @@ class TextsController < ApplicationController
     @texts = Text.where(genre: ["Basic", "Git", "HTML&CSS", "Ruby", "Ruby on Rails"]).order(id: :asc)
   end
 
+  def show
+    @texts = Text.find(params[:id])
+  end
+
 
 end

--- a/app/controllers/texts_controller.rb
+++ b/app/controllers/texts_controller.rb
@@ -5,7 +5,7 @@ class TextsController < ApplicationController
   end
 
   def show
-    @texts = Text.find(params[:id])
+    @text = Text.find(params[:id])
   end
 
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,4 @@
-module ApplicationHelper 
+module ApplicationHelper
   def max_width
     # 後に条件分岐が必要
     if devise_controller?
@@ -9,4 +9,51 @@ module ApplicationHelper
       "mw-md"
     end
   end
+
+    require "redcarpet"
+    require "coderay"
+
+    class HTMLwithCoderay < Redcarpet::Render::HTML
+        def block_code(code, language)
+            language = language.split(':')[0] if language.present?
+
+            case language.to_s
+            when 'rb'
+                lang = :ruby
+            when 'yml'
+                lang = :yaml
+            when 'css'
+                lang = :css
+            when 'html'
+                lang = :html
+            when ''
+                lang = :md
+            else
+                lang = language
+            end
+
+            CodeRay.scan(code, lang).div
+        end
+    end
+
+    def markdown(text)
+        html_render = HTMLwithCoderay.new(
+          filter_html: true,
+          hard_wrap: true,
+          link_attributes: { rel: 'nofollow', target: "_blank" }
+        )
+        options = {
+            autolink: true,
+            space_after_headers: true,
+            no_intra_emphasis: true,
+            fenced_code_blocks: true,
+            tables: true,
+            hard_wrap: true,
+            xhtml: true,
+            lax_html_blocks: true,
+            strikethrough: true
+        }
+        markdown = Redcarpet::Markdown.new(html_render, options)
+        markdown.render(text).html_safe
+    end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -10,8 +10,6 @@ module ApplicationHelper
     end
   end
 
-    require "redcarpet"
-    require "coderay"
 
     class HTMLwithCoderay < Redcarpet::Render::HTML
         def block_code(code, language)

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,1 +1,1 @@
-<p>内容 <%= @text.content %></p>
+<%= markdown(@text.content) %>

--- a/app/views/texts/show.html.erb
+++ b/app/views/texts/show.html.erb
@@ -1,0 +1,1 @@
+<p>内容 <%= @text.content %></p>


### PR DESCRIPTION
## issue 番号（必須）
close #16

## 実装内容
- Markdown機能実装
  - Gemfileにgem追加
  - application_helper.rbにmarkdownメソッドを定義
  
- 詳細ページの実装
  - showアクション追加
  - 詳細ページのビューファイル実装

## 参考資料
- Markdown機能
  - [Markdownの導入](https://arcane-gorge-21903.herokuapp.com/texts/224)

## チェックリスト

【補足】プルリクを出した後，クリックでチェックを入れて下さい

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考（必要があれば）
